### PR TITLE
feat: add Astro support

### DIFF
--- a/eslint-inspector.config.ts
+++ b/eslint-inspector.config.ts
@@ -1,6 +1,7 @@
 import { sxzz } from './src/index.ts'
 
 export default sxzz({
+  astro: true,
   vue: true,
   unocss: true,
   pnpm: true,

--- a/package.json
+++ b/package.json
@@ -43,10 +43,14 @@
   },
   "peerDependencies": {
     "@unocss/eslint-plugin": ">=65.0.0",
-    "eslint": "^9.5.0"
+    "eslint": "^9.5.0",
+    "eslint-plugin-astro": ">=1.0.0"
   },
   "peerDependenciesMeta": {
     "@unocss/eslint-plugin": {
+      "optional": true
+    },
+    "eslint-plugin-astro": {
       "optional": true
     }
   },
@@ -88,6 +92,7 @@
     "@unocss/eslint-plugin": "catalog:plugins",
     "bumpp": "catalog:dev",
     "eslint": "catalog:",
+    "eslint-plugin-astro": "catalog:plugins",
     "eslint-typegen": "catalog:dev",
     "prettier": "catalog:dev",
     "rolldown-plugin-require-cjs": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     eslint-plugin-antfu:
       specifier: ^3.1.3
       version: 3.1.3
+    eslint-plugin-astro:
+      specifier: ^1.5.0
+      version: 1.5.0
     eslint-plugin-baseline-js:
       specifier: ^0.4.2
       version: 0.4.2
@@ -249,6 +252,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
+      eslint-plugin-astro:
+        specifier: catalog:plugins
+        version: 1.5.0(eslint@9.39.2(jiti@2.6.1))
       eslint-typegen:
         specifier: catalog:dev
         version: 2.3.0(eslint@9.39.2(jiti@2.6.1))
@@ -285,6 +291,9 @@ packages:
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
     engines: {node: '>=20'}
+
+  '@astrojs/compiler@2.13.0':
+    resolution: {integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==}
 
   '@babel/generator@8.0.0-beta.4':
     resolution: {integrity: sha512-5xRfRZk6wx1BRu2XnTE8cTh2mx1ixrZ3/vpn7p/RCJpgctL6pexVVHE3eqtwlYvHhPAuOYCAlnsAyXpBdmfh5Q==}
@@ -600,6 +609,18 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@oxc-parser/binding-android-arm64@0.99.0':
     resolution: {integrity: sha512-V4jhmKXgQQdRnm73F+r3ZY4pUEsijQeSraFeaCGng7abSNJGs76X6l82wHnmjLGFAeY00LWtjcELs7ZmbJ9+lA==}
@@ -973,6 +994,16 @@ packages:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
 
+  astro-eslint-parser@1.2.2:
+    resolution: {integrity: sha512-JepyLROIad6f44uyqMF6HKE2QbunNzp3mYKRcPoDGt0QkxXmH222FAFC64WTyQu2Kg8NNEXHTN/sWuUId9sSxw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  astrojs-compiler-sync@1.1.1:
+    resolution: {integrity: sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ==}
+    engines: {node: ^18.18.0 || >=20.9.0}
+    peerDependencies:
+      '@astrojs/compiler': '>=0.27.0'
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -991,6 +1022,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1178,6 +1213,10 @@ packages:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
@@ -1240,6 +1279,12 @@ packages:
     resolution: {integrity: sha512-Az1QuqQJ/c2efWCxVxF249u3D4AcAu1Y3VCGAlJm+x4cgnn1ybUAnCT5DWVcogeaWduQKeVw07YFydVTOF4xDw==}
     peerDependencies:
       eslint: '*'
+
+  eslint-plugin-astro@1.5.0:
+    resolution: {integrity: sha512-IWy4kY3DKTJxd7g652zIWpBGFuxw7NIIt16kyqc8BlhnIKvI8yGJj+Maua0DiNYED3F/D8AmzoTTTA6A95WX9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.57.0'
 
   eslint-plugin-baseline-js@0.4.2:
     resolution: {integrity: sha512-SAbSTWrdOSlDhTXh5SYmLGzTajwMk7CtmyF+xI1Ain8DNw+F9Plk/wvqNPoe29DhvE5s9AEvwf/ZTU1I3bvYyw==}
@@ -1443,11 +1488,18 @@ packages:
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -1467,6 +1519,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
@@ -1496,6 +1552,10 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1580,6 +1640,10 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1699,6 +1763,10 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
@@ -1786,6 +1854,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1802,6 +1874,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -1882,6 +1959,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
@@ -1902,6 +1983,10 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1930,6 +2015,9 @@ packages:
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -1972,6 +2060,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rolldown-plugin-dts@0.21.6:
     resolution: {integrity: sha512-gePhzvZJRB0JIb/NyngEsMt3FPQtM4BXCLkxz7u1ggge2PmlZ7uOwmHjeBEsBiBRjOY12SdtEl7BmI3T1779ZA==}
     engines: {node: '>=20.19.0'}
@@ -2002,6 +2094,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -2022,6 +2117,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
@@ -2059,6 +2158,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   to-valid-identifier@1.0.0:
     resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
@@ -2257,6 +2360,8 @@ snapshots:
       semver: 7.7.3
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
+
+  '@astrojs/compiler@2.13.0': {}
 
   '@babel/generator@8.0.0-beta.4':
     dependencies:
@@ -2531,6 +2636,18 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@oxc-parser/binding-android-arm64@0.99.0':
     optional: true
@@ -2849,6 +2966,28 @@ snapshots:
       estree-walker: 3.0.3
       pathe: 2.0.3
 
+  astro-eslint-parser@1.2.2:
+    dependencies:
+      '@astrojs/compiler': 2.13.0
+      '@typescript-eslint/scope-manager': 8.53.1
+      '@typescript-eslint/types': 8.53.1
+      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@2.13.0)
+      debug: 4.4.3
+      entities: 6.0.1
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  astrojs-compiler-sync@1.1.1(@astrojs/compiler@2.13.0):
+    dependencies:
+      '@astrojs/compiler': 2.13.0
+      synckit: 0.11.12
+
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.9.18: {}
@@ -2865,6 +3004,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   browserslist@4.28.1:
     dependencies:
@@ -3026,6 +3169,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@6.0.1: {}
+
   esbuild@0.27.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.2
@@ -3096,6 +3241,20 @@ snapshots:
   eslint-plugin-antfu@3.1.3(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
+
+  eslint-plugin-astro@1.5.0(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@typescript-eslint/types': 8.53.1
+      astro-eslint-parser: 1.2.2
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-compat-utils: 0.6.5(eslint@9.39.2(jiti@2.6.1))
+      globals: 16.5.0
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-baseline-js@0.4.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -3380,9 +3539,21 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fault@2.0.1:
     dependencies:
@@ -3397,6 +3568,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   find-up-simple@1.0.1: {}
 
@@ -3428,6 +3603,10 @@ snapshots:
       pathe: 2.0.3
 
   github-slugger@2.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -3493,6 +3672,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -3677,6 +3858,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -3876,6 +4059,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -3894,6 +4082,8 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
@@ -3980,6 +4170,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.1: {}
+
   picomatch@4.0.3: {}
 
   pkg-types@1.3.1:
@@ -4005,6 +4197,12 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -4025,6 +4223,8 @@ snapshots:
   quansync@0.2.11: {}
 
   quansync@1.0.0: {}
+
+  queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
 
@@ -4057,6 +4257,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  reusify@1.1.0: {}
 
   rolldown-plugin-dts@0.21.6(@typescript/native-preview@7.0.0-dev.20260124.1)(rolldown@1.0.0-rc.1)(typescript@5.9.3):
     dependencies:
@@ -4103,6 +4305,10 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -4120,6 +4326,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  source-map-js@1.2.1: {}
 
   spdx-exceptions@2.5.0: {}
 
@@ -4150,6 +4358,10 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   to-valid-identifier@1.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalogs:
     eslint-config-flat-gitignore: ^2.1.0
     eslint-config-prettier: ^10.1.8
     eslint-plugin-antfu: ^3.1.3
+    eslint-plugin-astro: ^1.5.0
     eslint-plugin-baseline-js: ^0.4.2
     eslint-plugin-command: ^3.4.0
     eslint-plugin-de-morgan: ^2.0.0

--- a/src/configs/astro.ts
+++ b/src/configs/astro.ts
@@ -1,0 +1,11 @@
+import type { Config } from '../types'
+
+export const astro = async (): Promise<Config[]> => {
+  const pluginAstro = await import('eslint-plugin-astro')
+  return (pluginAstro.default.configs.recommended as Config[]).map(
+    (config) => ({
+      ...config,
+      name: `sxzz/${config.name || 'anonymous'}`,
+    }),
+  )
+}

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,3 +1,4 @@
+export * from './astro'
 export * from './baseline'
 export * from './command'
 export * from './comments'

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,6 +7,7 @@ export const hasVue = (): boolean =>
   isPackageExists('nuxt') ||
   isPackageExists('vitepress') ||
   isPackageExists('@slidev/cli')
+export const hasAstro = (): boolean => isPackageExists('astro')
 export const hasUnocss = (): boolean =>
   isPackageExists('unocss') ||
   isPackageExists('@unocss/webpack') ||

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -16,6 +16,7 @@ export const GLOB_JSON = '**/*.json'
 export const GLOB_JSON5 = '**/*.json5'
 export const GLOB_JSONC = '**/*.jsonc'
 
+export const GLOB_ASTRO = '**/*.astro'
 export const GLOB_MARKDOWN = '**/*.md'
 export const GLOB_VUE = '**/*.vue'
 export const GLOB_YAML = '**/*.y?(a)ml'
@@ -26,6 +27,7 @@ export const GLOB_ALL_SRC: string[] = [
   GLOB_STYLE,
   GLOB_JSON,
   GLOB_JSON5,
+  GLOB_ASTRO,
   GLOB_MARKDOWN,
   GLOB_VUE,
   GLOB_YAML,

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -4,6 +4,7 @@ import {
   type Awaitable,
 } from 'eslint-flat-config-utils'
 import {
+  astro,
   baseline,
   command,
   comments,
@@ -30,7 +31,7 @@ import {
   yml,
   type BaselineOptions,
 } from './configs'
-import { hasUnocss, hasVue } from './env'
+import { hasAstro, hasUnocss, hasVue } from './env'
 import type { ConfigNames } from './typegen'
 import type { Config } from './types'
 import type { Linter } from 'eslint'
@@ -77,6 +78,7 @@ export const presetBasic = (): Config[] => [
 export const presetAll = async (): Promise<Config[]> => [
   ...presetBasic(),
   ...presetLangsExtensions(),
+  ...(await astro()),
   ...vue(),
   ...(await unocss()),
   ...prettier(),
@@ -88,6 +90,8 @@ export const presetAll = async (): Promise<Config[]> => [
 
 /// keep-sorted
 export interface Options {
+  /** Astro support. Auto-enable if detected. */
+  astro?: boolean
   /** @default true */
   baseline?: boolean | BaselineOptions
   /** @default true */
@@ -112,6 +116,7 @@ export function sxzz(
   >[]
 ): FlatConfigComposer<Config, ConfigNames> {
   const {
+    astro: enableAstro = hasAstro(),
     baseline: enableBaseline = true,
     command: enableCommand = true,
     markdown: enableMarkdown = true,
@@ -122,6 +127,9 @@ export function sxzz(
   } = options
 
   const configs: Awaitable<Config[]>[] = [presetBasic(), yml(), presetJsonc()]
+  if (enableAstro) {
+    configs.push(astro())
+  }
   if (enableBaseline) {
     configs.push(
       baseline(typeof enableBaseline === 'object' ? enableBaseline : {}),

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -826,6 +826,276 @@ export interface Rules {
    */
   'arrow-spacing'?: Linter.RuleEntry<ArrowSpacing>
   /**
+   * apply `jsx-a11y/alt-text` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/alt-text/
+   */
+  'astro/jsx-a11y/alt-text'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/anchor-ambiguous-text` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/anchor-ambiguous-text/
+   */
+  'astro/jsx-a11y/anchor-ambiguous-text'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/anchor-has-content` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/anchor-has-content/
+   */
+  'astro/jsx-a11y/anchor-has-content'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/anchor-is-valid` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/anchor-is-valid/
+   */
+  'astro/jsx-a11y/anchor-is-valid'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/aria-activedescendant-has-tabindex` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-activedescendant-has-tabindex/
+   */
+  'astro/jsx-a11y/aria-activedescendant-has-tabindex'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/aria-props` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-props/
+   */
+  'astro/jsx-a11y/aria-props'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/aria-proptypes` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-proptypes/
+   */
+  'astro/jsx-a11y/aria-proptypes'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/aria-role` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-role/
+   */
+  'astro/jsx-a11y/aria-role'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/aria-unsupported-elements` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-unsupported-elements/
+   */
+  'astro/jsx-a11y/aria-unsupported-elements'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/autocomplete-valid` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/autocomplete-valid/
+   */
+  'astro/jsx-a11y/autocomplete-valid'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/click-events-have-key-events` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/click-events-have-key-events/
+   */
+  'astro/jsx-a11y/click-events-have-key-events'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/control-has-associated-label` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/control-has-associated-label/
+   */
+  'astro/jsx-a11y/control-has-associated-label'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/heading-has-content` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/heading-has-content/
+   */
+  'astro/jsx-a11y/heading-has-content'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/html-has-lang` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/html-has-lang/
+   */
+  'astro/jsx-a11y/html-has-lang'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/iframe-has-title` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/iframe-has-title/
+   */
+  'astro/jsx-a11y/iframe-has-title'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/img-redundant-alt` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/img-redundant-alt/
+   */
+  'astro/jsx-a11y/img-redundant-alt'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/interactive-supports-focus` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/interactive-supports-focus/
+   */
+  'astro/jsx-a11y/interactive-supports-focus'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/label-has-associated-control` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/label-has-associated-control/
+   */
+  'astro/jsx-a11y/label-has-associated-control'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/lang` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/lang/
+   */
+  'astro/jsx-a11y/lang'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/media-has-caption` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/media-has-caption/
+   */
+  'astro/jsx-a11y/media-has-caption'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/mouse-events-have-key-events` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/mouse-events-have-key-events/
+   */
+  'astro/jsx-a11y/mouse-events-have-key-events'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-access-key` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-access-key/
+   */
+  'astro/jsx-a11y/no-access-key'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-aria-hidden-on-focusable` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-aria-hidden-on-focusable/
+   */
+  'astro/jsx-a11y/no-aria-hidden-on-focusable'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-autofocus` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-autofocus/
+   */
+  'astro/jsx-a11y/no-autofocus'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-distracting-elements` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-distracting-elements/
+   */
+  'astro/jsx-a11y/no-distracting-elements'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-interactive-element-to-noninteractive-role` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-interactive-element-to-noninteractive-role/
+   */
+  'astro/jsx-a11y/no-interactive-element-to-noninteractive-role'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-noninteractive-element-interactions` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-noninteractive-element-interactions/
+   */
+  'astro/jsx-a11y/no-noninteractive-element-interactions'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-noninteractive-element-to-interactive-role` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-noninteractive-element-to-interactive-role/
+   */
+  'astro/jsx-a11y/no-noninteractive-element-to-interactive-role'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-noninteractive-tabindex` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-noninteractive-tabindex/
+   */
+  'astro/jsx-a11y/no-noninteractive-tabindex'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-redundant-roles` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-redundant-roles/
+   */
+  'astro/jsx-a11y/no-redundant-roles'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/no-static-element-interactions` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-static-element-interactions/
+   */
+  'astro/jsx-a11y/no-static-element-interactions'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/prefer-tag-over-role` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/prefer-tag-over-role/
+   */
+  'astro/jsx-a11y/prefer-tag-over-role'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/role-has-required-aria-props` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/role-has-required-aria-props/
+   */
+  'astro/jsx-a11y/role-has-required-aria-props'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/role-supports-aria-props` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/role-supports-aria-props/
+   */
+  'astro/jsx-a11y/role-supports-aria-props'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/scope` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/scope/
+   */
+  'astro/jsx-a11y/scope'?: Linter.RuleEntry<[]>
+  /**
+   * apply `jsx-a11y/tabindex-no-positive` rule to Astro components
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/tabindex-no-positive/
+   */
+  'astro/jsx-a11y/tabindex-no-positive'?: Linter.RuleEntry<[]>
+  /**
+   * the client:only directive is missing the correct component's framework value
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/missing-client-only-directive-value/
+   */
+  'astro/missing-client-only-directive-value'?: Linter.RuleEntry<[]>
+  /**
+   * disallow conflicting set directives and child contents
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-conflict-set-directives/
+   */
+  'astro/no-conflict-set-directives'?: Linter.RuleEntry<[]>
+  /**
+   * disallow using deprecated `Astro.canonicalURL`
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-canonicalurl/
+   */
+  'astro/no-deprecated-astro-canonicalurl'?: Linter.RuleEntry<[]>
+  /**
+   * disallow using deprecated `Astro.fetchContent()`
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-fetchcontent/
+   */
+  'astro/no-deprecated-astro-fetchcontent'?: Linter.RuleEntry<[]>
+  /**
+   * disallow using deprecated `Astro.resolve()`
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-resolve/
+   */
+  'astro/no-deprecated-astro-resolve'?: Linter.RuleEntry<[]>
+  /**
+   * disallow using deprecated `getEntryBySlug()`
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-getentrybyslug/
+   */
+  'astro/no-deprecated-getentrybyslug'?: Linter.RuleEntry<[]>
+  /**
+   * disallow value export
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-exports-from-components/
+   */
+  'astro/no-exports-from-components'?: Linter.RuleEntry<[]>
+  /**
+   * disallow use of `set:html` to prevent XSS attack
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-set-html-directive/
+   */
+  'astro/no-set-html-directive'?: Linter.RuleEntry<[]>
+  /**
+   * disallow use of `set:text`
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-set-text-directive/
+   */
+  'astro/no-set-text-directive'?: Linter.RuleEntry<[]>
+  /**
+   * disallow inline `<script>` without `src` to encourage CSP-safe patterns
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unsafe-inline-scripts/
+   */
+  'astro/no-unsafe-inline-scripts'?: Linter.RuleEntry<AstroNoUnsafeInlineScripts>
+  /**
+   * disallow selectors defined in `style` tag that don't use in HTML
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unused-css-selector/
+   */
+  'astro/no-unused-css-selector'?: Linter.RuleEntry<[]>
+  /**
+   * disallow unused `define:vars={...}` in `style` tag
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unused-define-vars-in-style/
+   */
+  'astro/no-unused-define-vars-in-style'?: Linter.RuleEntry<[]>
+  /**
+   * require `class:list` directives instead of `class` with expressions
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/prefer-class-list-directive/
+   */
+  'astro/prefer-class-list-directive'?: Linter.RuleEntry<[]>
+  /**
+   * require use object instead of ternary expression in `class:list`
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/prefer-object-class-list/
+   */
+  'astro/prefer-object-class-list'?: Linter.RuleEntry<[]>
+  /**
+   * require use split array elements in `class:list`
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/prefer-split-class-list/
+   */
+  'astro/prefer-split-class-list'?: Linter.RuleEntry<AstroPreferSplitClassList>
+  /**
+   * Require or disallow semicolons instead of ASI
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/semi/
+   */
+  'astro/semi'?: Linter.RuleEntry<AstroSemi>
+  /**
+   * enforce sorting of attributes
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/sort-attributes/
+   */
+  'astro/sort-attributes'?: Linter.RuleEntry<AstroSortAttributes>
+  /**
+   * disallow warnings when compiling.
+   * @see https://ota-meshi.github.io/eslint-plugin-astro/rules/valid-compile/
+   */
+  'astro/valid-compile'?: Linter.RuleEntry<[]>
+  /**
    * disallow BigInt64Array/BigUint64Array usage
    */
   'baseline-js/no-bigint64array'?: Linter.RuleEntry<[]>
@@ -7316,6 +7586,30 @@ type ArrowParens = []|[("always" | "as-needed")]|[("always" | "as-needed"), {
 type ArrowSpacing = []|[{
   before?: boolean
   after?: boolean
+}]
+// ----- astro/no-unsafe-inline-scripts -----
+type AstroNoUnsafeInlineScripts = []|[{
+  allowDefineVars?: boolean
+  allowModuleScripts?: boolean
+  allowNonExecutingTypes?: string[]
+  allowNonce?: boolean
+}]
+// ----- astro/prefer-split-class-list -----
+type AstroPreferSplitClassList = []|[{
+  splitLiteral?: boolean
+}]
+// ----- astro/semi -----
+type AstroSemi = ([]|["never"]|["never", {
+  beforeStatementContinuationChars?: ("always" | "any" | "never")
+}] | []|["always"]|["always", {
+  omitLastInOneLineBlock?: boolean
+  omitLastInOneLineClassBody?: boolean
+}])
+// ----- astro/sort-attributes -----
+type AstroSortAttributes = []|[{
+  type?: ("alphabetical" | "line-length")
+  ignoreCase?: boolean
+  order?: ("asc" | "desc")
 }]
 // ----- baseline-js/use-baseline -----
 type BaselineJsUseBaseline = []|[{
@@ -16107,4 +16401,4 @@ type Yoda = []|[("always" | "never")]|[("always" | "never"), {
   onlyEquality?: boolean
 }]
 // Names of all the configs
-export type ConfigNames = 'sxzz/global-ignores' | 'sxzz/gitignore' | 'sxzz/js/recommended' | 'sxzz/js' | 'sxzz/comments/recommended' | 'sxzz/comments' | 'sxzz/imports' | 'sxzz/unicorn/unopinionated' | 'sxzz/unicorn' | 'sxzz/node' | 'sxzz/jsdoc' | 'sxzz/regexp' | 'sxzz/de-morgan' | 'sxzz/typescript > typescript-eslint/base' | 'sxzz/typescript > typescript-eslint/eslint-recommended' | 'sxzz/typescript > typescript-eslint/recommended' | 'sxzz/typescript' | 'sxzz/typescript/dts-rules' | 'sxzz/typescript/cjs-rules' | 'sxzz/sort/imports' | 'sxzz/markdown/recommended/plugin' | 'sxzz/markdown/recommended/processor' | 'sxzz/markdown/recommended/code-blocks' | 'sxzz/markdown-rules' | 'sxzz/yaml/standard' | 'sxzz/yaml/standard' | 'sxzz/yaml/standard' | 'sxzz/yaml/standard' | 'sxzz/yaml' | 'sxzz/json' | 'sxzz/sort/package.json' | 'sxzz/sort/tsconfig' | 'sxzz/sort/pnpm-workspace' | 'sxzz/vue/typescript > typescript-eslint/base' | 'sxzz/vue/typescript > typescript-eslint/eslint-recommended' | 'sxzz/vue/typescript > typescript-eslint/recommended' | 'sxzz/vue/typescript' | 'sxzz/vue' | 'sxzz/vue/reactivity-transform' | 'sxzz/unocss' | 'sxzz/prettier' | 'sxzz/command' | 'sxzz/pnpm/package-json' | 'sxzz/pnpm/pnpm-workspace-yaml' | 'sxzz/baseline' | 'sxzz/special/cli' | 'sxzz/special/tests' | 'sxzz/special/allow-default-export' | 'sxzz/special/github' | 'sxzz/special/components'
+export type ConfigNames = 'sxzz/global-ignores' | 'sxzz/gitignore' | 'sxzz/js/recommended' | 'sxzz/js' | 'sxzz/comments/recommended' | 'sxzz/comments' | 'sxzz/imports' | 'sxzz/unicorn/unopinionated' | 'sxzz/unicorn' | 'sxzz/node' | 'sxzz/jsdoc' | 'sxzz/regexp' | 'sxzz/de-morgan' | 'sxzz/typescript > typescript-eslint/base' | 'sxzz/typescript > typescript-eslint/eslint-recommended' | 'sxzz/typescript > typescript-eslint/recommended' | 'sxzz/typescript' | 'sxzz/typescript/dts-rules' | 'sxzz/typescript/cjs-rules' | 'sxzz/sort/imports' | 'sxzz/markdown/recommended/plugin' | 'sxzz/markdown/recommended/processor' | 'sxzz/markdown/recommended/code-blocks' | 'sxzz/markdown-rules' | 'sxzz/yaml/standard' | 'sxzz/yaml/standard' | 'sxzz/yaml/standard' | 'sxzz/yaml/standard' | 'sxzz/yaml' | 'sxzz/json' | 'sxzz/sort/package.json' | 'sxzz/sort/tsconfig' | 'sxzz/sort/pnpm-workspace' | 'sxzz/astro/astro/base/plugin' | 'sxzz/astro/astro/base' | 'sxzz/astro/astro/base/javascript' | 'sxzz/astro/astro/base/typescript' | 'sxzz/astro/astro/recommended' | 'sxzz/vue/typescript > typescript-eslint/base' | 'sxzz/vue/typescript > typescript-eslint/eslint-recommended' | 'sxzz/vue/typescript > typescript-eslint/recommended' | 'sxzz/vue/typescript' | 'sxzz/vue' | 'sxzz/vue/reactivity-transform' | 'sxzz/unocss' | 'sxzz/prettier' | 'sxzz/command' | 'sxzz/pnpm/package-json' | 'sxzz/pnpm/pnpm-workspace-yaml' | 'sxzz/baseline' | 'sxzz/special/cli' | 'sxzz/special/tests' | 'sxzz/special/allow-default-export' | 'sxzz/special/github' | 'sxzz/special/components'


### PR DESCRIPTION
Add Astro framework support with auto-detection and optional peer dependency. Follows the UnoCSS pattern: dynamically imports eslint-plugin-astro when enabled, with auto-detection based on astro package presence.